### PR TITLE
better document source maps + improve terser_file

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,4 +21,4 @@ Imports:
     V8,
     cli,
     rstudioapi
-RoxygenNote: 7.1.0
+RoxygenNote: 7.1.1.9000

--- a/R/terser.R
+++ b/R/terser.R
@@ -4,7 +4,8 @@
 #' @description JavaScript parser, mangler and compressor toolkit for ES6+.
 #'
 #' @param input Path to one or more JavaScript files.
-#' @param options Options for terser, see \url{https://terser.org/docs/api-reference}.
+#' @param options Options for terser, see \url{https://terser.org/docs/api-reference}
+#' and \url{https://terser.org/docs/cli-usage}.
 #' @param output Path where to write optimized code.
 #'
 #' @return a \code{list}.
@@ -28,6 +29,10 @@ terser_file <- function(input, options = terser_options(), output = NULL) {
   } else {
     if (!is.null(output)) {
       writeLines(text = result$code, con = output)
+      # save source map
+      if (length(result$map) > 0) {
+        writeLines(text = result$map, con = paste0(output, ".map"))
+      }
       return(invisible(result))
     } else {
       return(result)
@@ -58,7 +63,12 @@ terser <- function(code, options = terser_options()) {
   ctx$get("result")
 }
 
-#' @param ... Other options to use, see \url{https://terser.org/docs/api-reference} for details.
+#' @param ... Other options to use, see \url{https://terser.org/docs/api-reference}
+#' and \url{https://terser.org/docs/cli-usage} for details.
+#' Source maps are crucial to the debugging process, thereby making it possible to reconstruct the original
+#' JS code starting from a minified script. To correctly generate source map, pass the \code{sourceMap} option
+#' (see example). \code{includeSources = TRUE} is mandatory so that files may be retrieved by the web browser developer tools.
+#' The folder will have the provided \code{root} as name so it's important to name it consistently!
 #'
 #' @rdname terser
 #'

--- a/README.Rmd
+++ b/README.Rmd
@@ -88,6 +88,26 @@ terser_file(input = "path/to/file.js", output = "path/to/file.min.js")
 terser_file(input = c("path/to/file1.js", "path/to/file2.js"), output = "path/to/file.min.js")
 ```
 
+Source maps are crucial to the debugging process, thereby making it possible to reconstruct the original
+JS code starting from a minified script. To correctly generate a source map, pass the __sourceMap__ option to `terser_options`. 
+`includeSources = TRUE` is mandatory so that files may be retrieved by the web browser developer tools.
+The folder will have the provided __root__ as name so it is important to name it consistently:
+
+```{r}
+path <- system.file("testfiles/htmlwidgets.js", package = "jstools")
+# source maps options
+o <- terser_options(
+  sourceMap = list(
+    root = "../../htmlwidgets-sources",
+    filename = "file.min.js",
+    url = "file.min.js.map",
+    includeSources = TRUE
+  )
+)
+# returns a list containing the minified code an the source map
+terser_file(input = path, options = o)
+```
+
 
 ## JSHint : code validation
 
@@ -105,7 +125,6 @@ Use with a file :
 ```{r}
 path <- system.file("testfiles/example.js", package = "jstools")
 jshint_file(input = path)
-
 ```
 
 To validate a Shiny script, you can add `jQuery` and `Shiny` as global variables (same for `Htmlwidgets`:
@@ -118,9 +137,9 @@ You can check several scripts at once (for example custom Shiny input bindings i
 
 ```{r, eval=FALSE}
 bindings <- list.files(
-  path = system.file("assets", package = "shinyWidgets"), 
+  path = system.file("assets", package = "shinyWidgets"),
   pattern = "bindings\\.js$",
-  recursive = TRUE, 
+  recursive = TRUE,
   full.names = TRUE
 )
 jshint_file(input = bindings, options = jshint_options(jquery = TRUE, globals = list("Shiny")))
@@ -172,7 +191,7 @@ You can concatenate several files together:
 
 ```{r, eval=FALSE}
 crass_file(
-  input = c("path/to/file1.css", "path/to/file2.css"), 
+  input = c("path/to/file1.css", "path/to/file2.css"),
   output = "path/to/file.min.css"
 )
 ```
@@ -193,7 +212,7 @@ You can also concatenate several files together:
 
 ```{r, eval=FALSE}
 csso_file(
-  input = c("path/to/file1.css", "path/to/file2.css"), 
+  input = c("path/to/file1.css", "path/to/file2.css"),
   output = "path/to/file.min.css"
 )
 ```

--- a/README.Rmd
+++ b/README.Rmd
@@ -99,8 +99,8 @@ path <- system.file("testfiles/htmlwidgets.js", package = "jstools")
 o <- terser_options(
   sourceMap = list(
     root = "../../htmlwidgets-sources",
-    filename = "file.min.js",
-    url = "file.min.js.map",
+    filename = "htmlwidgets.min.js",
+    url = "htmlwidgets.min.js.map",
     includeSources = TRUE
   )
 )

--- a/README.md
+++ b/README.md
@@ -94,8 +94,8 @@ path <- system.file("testfiles/htmlwidgets.js", package = "jstools")
 o <- terser_options(
   sourceMap = list(
     root = "../../htmlwidgets-sources",
-    filename = "file.min.js",
-    url = "file.min.js.map",
+    filename = "htmlwidgets.min.js",
+    url = "htmlwidgets.min.js.map",
     includeSources = TRUE
   )
 )

--- a/README.md
+++ b/README.md
@@ -83,6 +83,26 @@ terser_file(input = "path/to/file.js", output = "path/to/file.min.js")
 terser_file(input = c("path/to/file1.js", "path/to/file2.js"), output = "path/to/file.min.js")
 ```
 
+Source maps are crucial to the debugging process, thereby making it possible to reconstruct the original
+JS code starting from a minified script. To correctly generate a source map, pass the __sourceMap__ option to `terser_options`. 
+`includeSources = TRUE` is mandatory so that files may be retrieved by the web browser developer tools.
+The folder will have the provided __root__ as name so it is important to name it consistently:
+
+```r
+path <- system.file("testfiles/htmlwidgets.js", package = "jstools")
+# source maps options
+o <- terser_options(
+  sourceMap = list(
+    root = "../../htmlwidgets-sources",
+    filename = "file.min.js",
+    url = "file.min.js.map",
+    includeSources = TRUE
+  )
+)
+# returns a list containing the minified code an the source map
+terser_file(input = path, options = o)
+```
+
 ## JSHint : code validation
 
 Via <https://jshint.com/>

--- a/examples/ex-terser.R
+++ b/examples/ex-terser.R
@@ -7,9 +7,18 @@ terser(list(
   "file2.js" = "add(1 + 2, 3 + 4);"
 ))
 # equivalent to:
-#> terser_file(c("file1.js", "file2.js"))
+# > terser_file(c("file1.js", "file2.js"))
 
 # With a file
 path <- system.file("testfiles/htmlwidgets.js", package = "jstools")
-terser_file(input = path)
-
+# source maps options
+o <- terser_options(
+  sourceMap = list(
+    root = "../../htmlwidgets-sources",
+    filename = "file.min.js",
+    url = "file.min.js.map",
+    includeSources = TRUE
+  )
+)
+# returns a list containing the minified code an the source map
+terser_file(input = path, options = o)

--- a/examples/ex-terser.R
+++ b/examples/ex-terser.R
@@ -15,8 +15,8 @@ path <- system.file("testfiles/htmlwidgets.js", package = "jstools")
 o <- terser_options(
   sourceMap = list(
     root = "../../htmlwidgets-sources",
-    filename = "file.min.js",
-    url = "file.min.js.map",
+    filename = "htmlwidgets.min.js",
+    url = "htmlwidgets.min.js.map",
     includeSources = TRUE
   )
 )

--- a/man/terser.Rd
+++ b/man/terser.Rd
@@ -54,8 +54,8 @@ path <- system.file("testfiles/htmlwidgets.js", package = "jstools")
 o <- terser_options(
   sourceMap = list(
     root = "../../htmlwidgets-sources",
-    filename = "file.min.js",
-    url = "file.min.js.map",
+    filename = "htmlwidgets.min.js",
+    url = "htmlwidgets.min.js.map",
     includeSources = TRUE
   )
 )

--- a/man/terser.Rd
+++ b/man/terser.Rd
@@ -15,14 +15,20 @@ terser_options(...)
 \arguments{
 \item{input}{Path to one or more JavaScript files.}
 
-\item{options}{Options for terser, see \url{https://terser.org/docs/api-reference}.}
+\item{options}{Options for terser, see \url{https://terser.org/docs/api-reference}
+and \url{https://terser.org/docs/cli-usage}.}
 
 \item{output}{Path where to write optimized code.}
 
 \item{code}{Character vector where each element represent a line of JavaScript code,
 or a list of character vectors.}
 
-\item{...}{Other options to use, see \url{https://terser.org/docs/api-reference} for details.}
+\item{...}{Other options to use, see \url{https://terser.org/docs/api-reference}
+and \url{https://terser.org/docs/cli-usage} for details.
+Source maps are crucial to the debugging process, thereby making it possible to reconstruct the original
+JS code starting from a minified script. To correctly generate source map, pass the \code{sourceMap} option
+(see example). \code{includeSources = TRUE} is mandatory so that files may be retrieved by the web browser developer tools.
+The folder will have the provided \code{root} as name so it's important to name it consistently!}
 }
 \value{
 a \code{list}.
@@ -40,10 +46,19 @@ terser(list(
   "file2.js" = "add(1 + 2, 3 + 4);"
 ))
 # equivalent to:
-#> terser_file(c("file1.js", "file2.js"))
+# > terser_file(c("file1.js", "file2.js"))
 
 # With a file
 path <- system.file("testfiles/htmlwidgets.js", package = "jstools")
-terser_file(input = path)
-
+# source maps options
+o <- terser_options(
+  sourceMap = list(
+    root = "../../htmlwidgets-sources",
+    filename = "file.min.js",
+    url = "file.min.js.map",
+    includeSources = TRUE
+  )
+)
+# returns a list containing the minified code an the source map
+terser_file(input = path, options = o)
 }


### PR DESCRIPTION
Added support for source map:

```r
library(jstools)
path <- system.file("testfiles/htmlwidgets.js", package = "jstools")
# source maps options
o <- terser_options(
  sourceMap = list(
    root = "../../htmlwidgets-sources",
    filename = "file.min.js",
    url = "file.min.js.map",
    includeSources = TRUE
  )
)
# returns a list containing the minified code an the source map
terser_file(input = path, options = o)
```